### PR TITLE
"decode" Event Callback

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -62,7 +62,7 @@ export default class Chunk {
 		};
 
 		decode((audioData) => {
-                        this.clip._fire('decode', audioData);
+			this.clip._fire('decode', audioData);
 			let numFrames = 0;
 
 			for (let i = this._firstByte; i < this.raw.length; i += 1) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -41,7 +41,7 @@ export default class Chunk {
 
 		this._firstByte = 0;
 
-		const decode = (callback: () => void, errback: (err: Error) => void) => {
+		const decode = (callback: (audioData: AudioBuffer) => void, errback: (err: Error) => void) => {
 			const buffer = slice(raw, this._firstByte, raw.length).buffer;
 
 			this.context.decodeAudioData(buffer, callback, err => {
@@ -61,7 +61,7 @@ export default class Chunk {
 			});
 		};
 
-		decode((audioData) => {
+		decode((audioData: AudioBuffer) => {
 			this.clip._fire('decode', audioData);
 			let numFrames = 0;
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -61,7 +61,8 @@ export default class Chunk {
 			});
 		};
 
-		decode(() => {
+		decode((audioData) => {
+                        this.clip._fire('decode', audioData);
 			let numFrames = 0;
 
 			for (let i = this._firstByte; i < this.raw.length; i += 1) {


### PR DESCRIPTION
For audio visualizations, such as rendering a waveform, its helpful to have access to the raw, decoded audio data. I poked around the source a bit but didn't see a clear way to access that decoded data so I added this event.

I wanted to get this change in front of you and get your thoughts. Thanks!