### PR TITLE
fix padding computation when calculating the frame length

### DIFF
--- a/src/utils/getFrameLength.ts
+++ b/src/utils/getFrameLength.ts
@@ -18,7 +18,7 @@ export default function getFrameLength(data: Uint8Array, i: number, metadata: Me
 
 	const bitrateCode = (data[i + 2] & 0b11110000) >> 4;
 	const bitrate = bitrateLookup[`${mpegVersion}${mpegLayer}`][bitrateCode] * 1e3;
-	const padding = (data[2] & 0b00000010) >> 1;
+	const padding = (data[i + 2] & 0b00000010) >> 1;
 
 	const length = ~~(mpegLayer === 1
 		? (12 * bitrate / sampleRate + padding) * 4


### PR DESCRIPTION
Hi @Rich-Harris, many thanks for providing this useful library.

I noticed a little bug in the computation of the padding value which is used to calculate the frame length. It always used the byte at index 2 which usually points to the first header. This causes an error for files with different padding values for different frames.

I just updated the code to read the third byte of the currently inspected header instead.

Please let me know if there is anything I need to change to make this pull request mergeable.